### PR TITLE
Fix previous version

### DIFF
--- a/src/Elders.Cronus.DomainModeling.Tests/When_parsing_entity_urn.cs
+++ b/src/Elders.Cronus.DomainModeling.Tests/When_parsing_entity_urn.cs
@@ -17,7 +17,7 @@ namespace Elders.Cronus
 
         It should_have_correct_entity_name = () => result.EntityName.ToString().ShouldEqual("entityname");
 
-        It should_have_correct_entity_id = () => result.Id.ShouldEqual("entityid");
+        It should_have_correct_entity_id = () => result.Id.ShouldEqual("arname:123/entityname/entityid");
 
         static StringTenantUrn aggUrn;
         static string urn;

--- a/src/Elders.Cronus.DomainModeling/Cronus.DomainModeling.rn.md
+++ b/src/Elders.Cronus.DomainModeling/Cronus.DomainModeling.rn.md
@@ -1,3 +1,6 @@
+#### 6.0.0-beta0007 - 03.12.2019
+* Added EntityId property for getting exactly the entity Id of the StringTenantEntityUrn
+
 #### 6.0.0-beta0006 - 03.12.2019
 * Changed Entity Id to be not only the guid of the entity but also to incluide in it self the id of the aggregate
 

--- a/src/Elders.Cronus.DomainModeling/Cronus.DomainModeling.rn.md
+++ b/src/Elders.Cronus.DomainModeling/Cronus.DomainModeling.rn.md
@@ -1,3 +1,6 @@
+#### 6.0.0-beta0006 - 03.12.2019
+* Changed Entity Id to be not only the guid of the entity but also to incluide in it self the id of the aggregate
+
 #### 6.0.0-beta0005 - 02.12.2019
 * Fix bug introduced in 6.0.0-beta0004
 

--- a/src/Elders.Cronus.DomainModeling/StringTenantEntityUrn.cs
+++ b/src/Elders.Cronus.DomainModeling/StringTenantEntityUrn.cs
@@ -9,7 +9,7 @@ namespace Elders.Cronus
         public StringTenantEntityUrn(StringTenantUrn arUrn, string entityName, string id)
             : base(arUrn.Tenant, $"{arUrn.NSS}{HIERARCHICAL_DELIMITER}{entityName}{HIERARCHICAL_DELIMITER}{id}".ToLower())
         {
-            Id = id.ToLower();
+            Id = $"{arUrn.NSS}{HIERARCHICAL_DELIMITER}{entityName}{HIERARCHICAL_DELIMITER}{id}".ToLower();
             AggregateUrn = arUrn ?? throw new ArgumentNullException(nameof(arUrn));
             EntityName = entityName.ToLower();
         }

--- a/src/Elders.Cronus.DomainModeling/StringTenantEntityUrn.cs
+++ b/src/Elders.Cronus.DomainModeling/StringTenantEntityUrn.cs
@@ -9,7 +9,7 @@ namespace Elders.Cronus
         public StringTenantEntityUrn(StringTenantUrn arUrn, string entityName, string id)
             : base(arUrn.Tenant, $"{arUrn.NSS}{HIERARCHICAL_DELIMITER}{entityName}{HIERARCHICAL_DELIMITER}{id}".ToLower())
         {
-            Id = $"{arUrn.NSS}{HIERARCHICAL_DELIMITER}{entityName}{HIERARCHICAL_DELIMITER}{id}".ToLower();
+            EntityId = id;
             AggregateUrn = arUrn ?? throw new ArgumentNullException(nameof(arUrn));
             EntityName = entityName.ToLower();
         }
@@ -18,7 +18,9 @@ namespace Elders.Cronus
 
         public string EntityName { get; private set; }
 
-        public string Id { get; private set; }
+        public string Id => $"{AggregateUrn.NSS}{HIERARCHICAL_DELIMITER}{EntityName}{HIERARCHICAL_DELIMITER}{EntityId}".ToLower();
+
+        public string EntityId { get; set; }
 
         new public static StringTenantEntityUrn Parse(string urn)
         {


### PR DESCRIPTION
# Title
Add EntityId to the StringTenantEntityUrn

### Description
For better flexibility Id of the StringTenantEntityUrn is changed to return the NSS part and a custom property EntityId was added to return only the GUID of the entity part so that we can build easier EntityId instances

### Test Methods
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->