### PR TITLE
Adds a markup interface for public events

### DIFF
--- a/src/Elders.Cronus.DomainModeling/IExternalEvent.cs
+++ b/src/Elders.Cronus.DomainModeling/IExternalEvent.cs
@@ -1,7 +1,0 @@
-﻿namespace Elders.Cronus
-{
-    /// <summary>
-    /// External domain events represent business changes which already happened in another bounded context
-    /// </summary>
-    public interface IExternalEvent : IMessage { }
-}

--- a/src/Elders.Cronus.DomainModeling/IPublicEvent.cs
+++ b/src/Elders.Cronus.DomainModeling/IPublicEvent.cs
@@ -1,0 +1,7 @@
+﻿namespace Elders.Cronus
+{
+    /// <summary>
+    /// An event which is part of the domain's Published Language
+    /// </summary>
+    public interface IPublicEvent : IMessage { }
+}


### PR DESCRIPTION
# Title
Adds a markup interface for public events which are part of a domain's published language

## Related Issue 
Elders/Cronus#203

### Description
Having such markup interface we could recognize such events and apply different workflows if needed. I am not sure yet if this interface has to inherit `IEvent`. For now I suggest to stick to the `IMessage` base interface.
