### PR TITLE
Urn hash code

### DIFF
--- a/src/Elders.Cronus.DomainModeling.Tests/When_comparing_equal_urns_using_equals_operator.cs
+++ b/src/Elders.Cronus.DomainModeling.Tests/When_comparing_equal_urns_using_equals_operator.cs
@@ -1,0 +1,13 @@
+﻿using Machine.Specifications;
+
+namespace Elders.Cronus
+{
+    [Subject("Urn")]
+    public class When_comparing_equal_urns_using_equals_operator
+    {
+        It should_be_true = () => (firstUrn == secondUrn).ShouldBeTrue();
+
+        static Urn firstUrn = new Urn("tenant", @"arname:abc123()+,-.:=@;$_!*'%99a");
+        static Urn secondUrn = new Urn("tenant", @"arname:abc123()+,-.:=@;$_!*'%99a");
+    }
+}

--- a/src/Elders.Cronus.DomainModeling.Tests/When_comparing_urns_with_nss_with_and_without_preencoded_character.cs
+++ b/src/Elders.Cronus.DomainModeling.Tests/When_comparing_urns_with_nss_with_and_without_preencoded_character.cs
@@ -7,6 +7,8 @@ namespace Elders.Cronus
     {
         It should_not_be_equal = () => firstUrn.ShouldNotEqual(secondUrn);
 
+        It should_not_have_equal_hashcodes = () => firstUrn.GetHashCode().ShouldNotEqual(secondUrn.GetHashCode());
+
         static IUrn firstUrn = new Urn("Tenant", @"arName:abc123()+,-.:=@;$_!*'%99a");
         static IUrn secondUrn = new Urn("tenant", @"arName:abc123()+%2c-.:=@;$_!*'%99a");
     }

--- a/src/Elders.Cronus.DomainModeling.Tests/When_comparing_urns_with_null_from_the_left_using_equals_operator.cs
+++ b/src/Elders.Cronus.DomainModeling.Tests/When_comparing_urns_with_null_from_the_left_using_equals_operator.cs
@@ -1,0 +1,15 @@
+﻿using Machine.Specifications;
+
+namespace Elders.Cronus
+{
+    [Subject("Urn")]
+    public class When_comparing_urns_with_null_from_the_left_using_equals_operator
+    {
+        It should_be_false = () => (null == urn).ShouldBeFalse();
+
+        It should_be_true = () => (null == nullUrn).ShouldBeTrue();
+
+        static Urn nullUrn = null;
+        static Urn urn = new Urn("tenant", @"arname:abc123()+,-.:=@;$_!*'%99a");
+    }
+}

--- a/src/Elders.Cronus.DomainModeling.Tests/When_comparing_urns_with_null_from_the_right_using_equals_operator.cs
+++ b/src/Elders.Cronus.DomainModeling.Tests/When_comparing_urns_with_null_from_the_right_using_equals_operator.cs
@@ -1,0 +1,15 @@
+﻿using Machine.Specifications;
+
+namespace Elders.Cronus
+{
+    [Subject("Urn")]
+    public class When_comparing_urns_with_null_from_the_right_using_equals_operator
+    {
+        It should_be_false = () => (urn == null).ShouldBeFalse();
+
+        It should_be_true = () => (nullUrn == null).ShouldBeTrue();
+
+        static Urn nullUrn = null;
+        static Urn urn = new Urn("tenant", @"arname:abc123()+,-.:=@;$_!*'%99a");
+    }
+}

--- a/src/Elders.Cronus.DomainModeling.Tests/When_comparing_urns_with_same_nids_and_nss_with_different_part_after_the_slash.cs
+++ b/src/Elders.Cronus.DomainModeling.Tests/When_comparing_urns_with_same_nids_and_nss_with_different_part_after_the_slash.cs
@@ -7,6 +7,8 @@ namespace Elders.Cronus
     {
         It should_not_be_equal = () => firstUrn.ShouldNotEqual(secondUrn);
 
+        It should_not_have_equal_hashcodes = () => firstUrn.GetHashCode().ShouldNotEqual(secondUrn.GetHashCode());
+
         static IUrn firstUrn = new Urn("Tenant", @"arName:abc123()+,-.:=@;$_!*'%99a/abc");
         static IUrn secondUrn = new Urn("tenant", @"arName:abc123()+,-.:=@;$_!*'%99a/dfg");
     }

--- a/src/Elders.Cronus.DomainModeling.Tests/When_comparing_urns_with_same_nids_with_different_cases.cs
+++ b/src/Elders.Cronus.DomainModeling.Tests/When_comparing_urns_with_same_nids_with_different_cases.cs
@@ -7,6 +7,8 @@ namespace Elders.Cronus
     {
         It should_be_equal = () => firstUrn.ShouldEqual(secondUrn);
 
+        It should_have_equal_hashcodes = () => firstUrn.GetHashCode().ShouldEqual(secondUrn.GetHashCode());
+
         static IUrn firstUrn = new Urn("Tenant", @"arName:abc123()+,-.:=@;$_!*'%99a");
         static IUrn secondUrn = new Urn("tenant", @"arName:abc123()+,-.:=@;$_!*'%99a");
     }

--- a/src/Elders.Cronus.DomainModeling.Tests/When_comparing_urns_with_same_nss_with_different_cases.cs
+++ b/src/Elders.Cronus.DomainModeling.Tests/When_comparing_urns_with_same_nss_with_different_cases.cs
@@ -5,7 +5,9 @@ namespace Elders.Cronus
     [Subject("Urn")]
     public class When_comparing_urns_with_same_nss_with_different_cases
     {
-        It should_be_equal = () => firstUrn.ShouldNotEqual(secondUrn);
+        It should_not_be_equal = () => firstUrn.ShouldNotEqual(secondUrn);
+
+        It should_not_have_equal_hashcodes = () => firstUrn.GetHashCode().ShouldNotEqual(secondUrn.GetHashCode());
 
         static IUrn firstUrn = new Urn("tenant", @"arname:abc123()+,-.:=@;$_!*'%99a");
         static IUrn secondUrn = new Urn("tenant", @"ArName:abc123()+,-.:=@;$_!*'%99a");

--- a/src/Elders.Cronus.DomainModeling/Urn.cs
+++ b/src/Elders.Cronus.DomainModeling/Urn.cs
@@ -275,5 +275,10 @@ namespace Elders.Cronus
         {
             return $"{NID.ToLower()}:{NSS}".Equals($"{other.NID.ToLower()}:{other.NSS}");
         }
+
+        public override int GetHashCode()
+        {
+            return HashCode.Combine(NID.ToLower(), NSS);
+        }
     }
 }

--- a/src/Elders.Cronus.DomainModeling/Urn.cs
+++ b/src/Elders.Cronus.DomainModeling/Urn.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Diagnostics.CodeAnalysis;
 using System.Runtime.Serialization;
 using System.Text;
 
@@ -222,6 +221,22 @@ namespace Elders.Cronus
         public static implicit operator string(Urn urn)
         {
             return urn.Value;
+        }
+
+        public static bool operator ==(Urn left, Urn right)
+        {
+            if (left is null && right is null)
+                return true;
+
+            if (left is null || right is null)
+                return false;
+
+            return left.Equals(right);
+        }
+
+        public static bool operator !=(Urn left, Urn right)
+        {
+            return !(left == right);
         }
 
         public static bool IsUrn(string candidate)


### PR DESCRIPTION
# Title
Overriding Urn.GetHashCode()

## Related Issue 
Closes Elders/Cronus#221

### Description
Overriding Urn.GetHashCode() and == operator

### Test Methods
Hash codes from two equal urns should be equal
Hash codes from two different urns should not be equal
Comparing equal urns using the == operator should evaluate to true
Comparing a urn with null using the == operator should evaluate to false
Comparing a urn null reference with null using the == operator should evaluate to true