### PR TITLE
Fix Elders/Cronus#239

### DIFF
--- a/src/Elders.Cronus.DomainModeling.Tests/When_resolving_bounded_context_from_a_message_without__DataContractAttribute__.cs
+++ b/src/Elders.Cronus.DomainModeling.Tests/When_resolving_bounded_context_from_a_message_without__DataContractAttribute__.cs
@@ -1,0 +1,15 @@
+﻿using Machine.Specifications;
+
+namespace Elders.Cronus
+{
+    [Subject("MessageInfo")]
+    public class When_resolving_bounded_context_from_a_message_without__DataContractAttribute__
+    {
+        Because of = () => result = typeof(IPublicEvent).GetBoundedContext("elders");
+
+        It should_resolve_the_default_bounded_context = () => result.ShouldEqual("elders");
+
+        static string result;
+
+    }
+}

--- a/src/Elders.Cronus.DomainModeling/Cronus.DomainModeling.rn.md
+++ b/src/Elders.Cronus.DomainModeling/Cronus.DomainModeling.rn.md
@@ -1,3 +1,6 @@
+#### 6.0.2 - 27.04.2020
+* Fixes an unexpected exceptio when trying to resolve bounded context name from a type which does not have a DataContractAttribute [#239]
+
 #### 6.0.1 - 23.04.2020
 * Changes the Urn.Parse return type from IUrn to Urn. This is a regression. [#235]
 

--- a/src/Elders.Cronus.DomainModeling/MessageInfo.cs
+++ b/src/Elders.Cronus.DomainModeling/MessageInfo.cs
@@ -71,7 +71,7 @@ namespace Elders.Cronus
                 .GetCustomAttributes(false).Where(attr => attr is DataContractAttribute)
                 .SingleOrDefault() as DataContractAttribute;
 
-            if (contract.IsNamespaceSetExplicitly)
+            if (contract is null == false && contract.IsNamespaceSetExplicitly)
                 boundedContext = contract.Namespace;
 
             typeToBoundedContext.TryAdd(contractType, boundedContext);


### PR DESCRIPTION
# Title
Fixes unexpected exception

## Related Issue 
fixes Elders/Cronus#239

### Description
Fixes an unexpected exceptio when trying to resolve bounded context name from a type which does not have a DataContractAttribute
